### PR TITLE
Fix critical bug in topological sort

### DIFF
--- a/src/dpkg/installer.rs
+++ b/src/dpkg/installer.rs
@@ -60,8 +60,9 @@ impl DpkgExtracter {
       });
     }
 
+    // XXX should parse `Break` field instead using `--auto-deconfigure`.
     let output = Command::new("dpkg")
-      .args(&["--unpack", &archived_fullname])
+      .args(&["--auto-deconfigure", "--unpack", &archived_fullname])
       .output()
       .unwrap();
     if output.status.success() {


### PR DESCRIPTION
どえらいバグがあったわ

```.diff
--- a/src/algorithm/dag.rs
+++ b/src/algorithm/dag.rs
@@ -185,7 +185,7 @@ impl Graph {
     self.simplified_nodes[start].visited = true;

     for jx in 0..self.simplified_nodes[start].to.len() {
-      self.topological_dfs(jx);
+      self.topological_dfs(self.simplified_nodes[start].to[jx] as usize);
     }
```

fix #1 
